### PR TITLE
Rename references from master to main

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -37,9 +37,9 @@ We're really grateful for your presentation at ConFoo 2020. Please use this guid
 
 6. Commit the changes.
 
-7. `git push origin master` to send the changes to your forked repository.
+7. `git push origin main` to send the changes to your forked repository.
 
-8. Return to the master repository, and create a pull request.
+8. Return to the `main` repository, and create a pull request.
 
 9. In short order, we'll merge your changes into place, and your presentation content will be available to all.
 


### PR DESCRIPTION
Sine the repo is using `main` as the default branch instead of `master`. After this change, the right branch will be used in `CONTRIBUTING.md`.